### PR TITLE
mpi variants

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,14 +10,32 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_python2.7:
-        CONFIG: linux_python2.7
+      linux_mpimpichpython2.7:
+        CONFIG: linux_mpimpichpython2.7
         UPLOAD_PACKAGES: True
-      linux_python3.6:
-        CONFIG: linux_python3.6
+      linux_mpimpichpython3.6:
+        CONFIG: linux_mpimpichpython3.6
         UPLOAD_PACKAGES: True
-      linux_python3.7:
-        CONFIG: linux_python3.7
+      linux_mpimpichpython3.7:
+        CONFIG: linux_mpimpichpython3.7
+        UPLOAD_PACKAGES: True
+      linux_mpinompipython2.7:
+        CONFIG: linux_mpinompipython2.7
+        UPLOAD_PACKAGES: True
+      linux_mpinompipython3.6:
+        CONFIG: linux_mpinompipython3.6
+        UPLOAD_PACKAGES: True
+      linux_mpinompipython3.7:
+        CONFIG: linux_mpinompipython3.7
+        UPLOAD_PACKAGES: True
+      linux_mpiopenmpipython2.7:
+        CONFIG: linux_mpiopenmpipython2.7
+        UPLOAD_PACKAGES: True
+      linux_mpiopenmpipython3.6:
+        CONFIG: linux_mpiopenmpipython3.6
+        UPLOAD_PACKAGES: True
+      linux_mpiopenmpipython3.7:
+        CONFIG: linux_mpiopenmpipython3.7
         UPLOAD_PACKAGES: True
   steps:
   - script: |

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -10,14 +10,32 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      osx_python2.7:
-        CONFIG: osx_python2.7
+      osx_mpimpichpython2.7:
+        CONFIG: osx_mpimpichpython2.7
         UPLOAD_PACKAGES: True
-      osx_python3.6:
-        CONFIG: osx_python3.6
+      osx_mpimpichpython3.6:
+        CONFIG: osx_mpimpichpython3.6
         UPLOAD_PACKAGES: True
-      osx_python3.7:
-        CONFIG: osx_python3.7
+      osx_mpimpichpython3.7:
+        CONFIG: osx_mpimpichpython3.7
+        UPLOAD_PACKAGES: True
+      osx_mpinompipython2.7:
+        CONFIG: osx_mpinompipython2.7
+        UPLOAD_PACKAGES: True
+      osx_mpinompipython3.6:
+        CONFIG: osx_mpinompipython3.6
+        UPLOAD_PACKAGES: True
+      osx_mpinompipython3.7:
+        CONFIG: osx_mpinompipython3.7
+        UPLOAD_PACKAGES: True
+      osx_mpiopenmpipython2.7:
+        CONFIG: osx_mpiopenmpipython2.7
+        UPLOAD_PACKAGES: True
+      osx_mpiopenmpipython3.6:
+        CONFIG: osx_mpiopenmpipython3.6
+        UPLOAD_PACKAGES: True
+      osx_mpiopenmpipython3.7:
+        CONFIG: osx_mpiopenmpipython3.7
         UPLOAD_PACKAGES: True
 
   steps:

--- a/.ci_support/linux_mpimpichpython2.7.yaml
+++ b/.ci_support/linux_mpimpichpython2.7.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- mpich
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '2.7'
+readline:
+- '7.0'

--- a/.ci_support/linux_mpimpichpython3.6.yaml
+++ b/.ci_support/linux_mpimpichpython3.6.yaml
@@ -1,21 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '4'
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '4'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- mpich
 ncurses:
 - '6.1'
 numpy:

--- a/.ci_support/linux_mpimpichpython3.7.yaml
+++ b/.ci_support/linux_mpimpichpython3.7.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- mpich
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '3.7'
+readline:
+- '7.0'

--- a/.ci_support/linux_mpinompipython2.7.yaml
+++ b/.ci_support/linux_mpinompipython2.7.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- nompi
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '2.7'
+readline:
+- '7.0'

--- a/.ci_support/linux_mpinompipython3.6.yaml
+++ b/.ci_support/linux_mpinompipython3.6.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- nompi
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '3.6'
+readline:
+- '7.0'

--- a/.ci_support/linux_mpinompipython3.7.yaml
+++ b/.ci_support/linux_mpinompipython3.7.yaml
@@ -12,6 +12,8 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+mpi:
+- nompi
 ncurses:
 - '6.1'
 numpy:
@@ -25,6 +27,6 @@ pin_run_as_build:
   readline:
     max_pin: x
 python:
-- '2.7'
+- '3.7'
 readline:
 - '7.0'

--- a/.ci_support/linux_mpiopenmpipython2.7.yaml
+++ b/.ci_support/linux_mpiopenmpipython2.7.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- openmpi
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '2.7'
+readline:
+- '7.0'

--- a/.ci_support/linux_mpiopenmpipython3.6.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.6.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- openmpi
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '3.6'
+readline:
+- '7.0'

--- a/.ci_support/linux_mpiopenmpipython3.7.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.7.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- openmpi
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '3.7'
+readline:
+- '7.0'

--- a/.ci_support/osx_mpimpichpython2.7.yaml
+++ b/.ci_support/osx_mpimpichpython2.7.yaml
@@ -1,17 +1,23 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '4'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- mpich
 ncurses:
 - '6.1'
 numpy:
@@ -25,6 +31,6 @@ pin_run_as_build:
   readline:
     max_pin: x
 python:
-- '3.7'
+- '2.7'
 readline:
 - '7.0'

--- a/.ci_support/osx_mpimpichpython3.6.yaml
+++ b/.ci_support/osx_mpimpichpython3.6.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '4'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- mpich
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '3.6'
+readline:
+- '7.0'

--- a/.ci_support/osx_mpimpichpython3.7.yaml
+++ b/.ci_support/osx_mpimpichpython3.7.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '4'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- mpich
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '3.7'
+readline:
+- '7.0'

--- a/.ci_support/osx_mpinompipython2.7.yaml
+++ b/.ci_support/osx_mpinompipython2.7.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '4'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- nompi
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '2.7'
+readline:
+- '7.0'

--- a/.ci_support/osx_mpinompipython3.6.yaml
+++ b/.ci_support/osx_mpinompipython3.6.yaml
@@ -16,6 +16,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+mpi:
+- nompi
 ncurses:
 - '6.1'
 numpy:
@@ -29,6 +31,6 @@ pin_run_as_build:
   readline:
     max_pin: x
 python:
-- '3.7'
+- '3.6'
 readline:
 - '7.0'

--- a/.ci_support/osx_mpinompipython3.7.yaml
+++ b/.ci_support/osx_mpinompipython3.7.yaml
@@ -1,17 +1,23 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '4'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- nompi
 ncurses:
 - '6.1'
 numpy:
@@ -25,6 +31,6 @@ pin_run_as_build:
   readline:
     max_pin: x
 python:
-- '3.6'
+- '3.7'
 readline:
 - '7.0'

--- a/.ci_support/osx_mpiopenmpipython2.7.yaml
+++ b/.ci_support/osx_mpiopenmpipython2.7.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '4'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- openmpi
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '2.7'
+readline:
+- '7.0'

--- a/.ci_support/osx_mpiopenmpipython3.6.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.6.yaml
@@ -16,6 +16,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+mpi:
+- openmpi
 ncurses:
 - '6.1'
 numpy:
@@ -29,6 +31,6 @@ pin_run_as_build:
   readline:
     max_pin: x
 python:
-- '2.7'
+- '3.6'
 readline:
 - '7.0'

--- a/.ci_support/osx_mpiopenmpipython3.7.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.7.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '4'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- openmpi
+ncurses:
+- '6.1'
+numpy:
+- '1.9'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+python:
+- '3.7'
+readline:
+- '7.0'

--- a/README.md
+++ b/README.md
@@ -29,45 +29,129 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_python2.7</td>
+              <td>linux_mpimpichpython2.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_python2.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_mpimpichpython2.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.6</td>
+              <td>linux_mpimpichpython3.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_mpimpichpython3.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.7</td>
+              <td>linux_mpimpichpython3.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_mpimpichpython3.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python2.7</td>
+              <td>linux_mpinompipython2.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_python2.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_mpinompipython2.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.6</td>
+              <td>linux_mpinompipython3.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_mpinompipython3.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.7</td>
+              <td>linux_mpinompipython3.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_mpinompipython3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_mpiopenmpipython2.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_mpiopenmpipython2.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_mpiopenmpipython3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_mpiopenmpipython3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_mpiopenmpipython3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=linux&configuration=linux_mpiopenmpipython3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpimpichpython2.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_mpimpichpython2.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpimpichpython3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_mpimpichpython3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpimpichpython3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_mpimpichpython3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpinompipython2.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_mpinompipython2.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpinompipython3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_mpinompipython3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpinompipython3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_mpinompipython3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpiopenmpipython2.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_mpiopenmpipython2.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpiopenmpipython3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_mpiopenmpipython3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpiopenmpipython3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=679&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/neuron-feedstock?branchName=master&jobName=osx&configuration=osx_mpiopenmpipython3.7" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,11 +21,19 @@ find share/lib/python -name "*.cpp" -exec rm {} \;
 aclocal -Im4
 automake
 autoconf
+
+EXTRA_CONFIG=""
+if [[ ! -z "$mpi" && "$mpi" != "nompi" ]]; then
+  EXTRA_CONFIG="--with-mpi $EXTRA_CONFIG"
+fi
+
+
 ./configure \
     --without-x \
     --with-nrnpython=$PYTHON \
     --prefix=$PREFIX \
-    --exec-prefix=$PREFIX
+    --exec-prefix=$PREFIX \
+    $EXTRA_CONFIG
 
 make -j ${NUM_CPUS:-1}
 make install

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+mpi:
+  - nompi
+  - mpich
+  - openmpi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ build:
   {% else %}
   {% set mpi_prefix = "mpi_" + mpi %}
   {% endif %}
-  string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
+  string: "{{ mpi_prefix }}_py{{ py }}h{{ PKG_HASH }}_{{ build }}"
 
   run_exports:
     {% if mpi == "nompi" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,17 @@
 {% set version = "7.6.7" %}
-
 {% set xy = version.rsplit('.', 1)[0] %}
+{% set build = 1 %}
+
+{% if not mpi %}
+# conda-smithy misbehaves if mpi is unset
+{% set mpi = 'nompi' %}
+{% endif %}
+
+{% if mpi == 'nompi' %}
+# prioritize nompi variant via build number
+{% set build = build + 100 %}
+{% endif %}
+
 package:
   name: neuron
   version: {{ version }}
@@ -13,10 +24,27 @@ source:
     - memacs.patch
 
 build:
-  number: 0
+  number: {{ build }}
   skip: true  # [win]
+
+  # add build string so packages can depend on
+  # mpi or nompi variants explicitly:
+  # `pkg * mpi_mpich_*` for mpich
+  # `pkg * mpi_*` for any mpi
+  # `pkg * nompi_*` for no mpi
+  {% if mpi == "nompi" %}
+  {% set mpi_prefix = "nompi" %}
+  {% else %}
+  {% set mpi_prefix = "mpi_" + mpi %}
+  {% endif %}
+  string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
+
   run_exports:
+    {% if mpi == "nompi" %}
     - {{ pin_compatible("neuron") }}
+    {% else %}
+    - {{ pin_compatible("neuron") }} {{ mpi_prefix }}_*
+    {% endif %}
 
 requirements:
   build:
@@ -34,11 +62,13 @@ requirements:
     - numpy
     - readline
     - ncurses
+    - {{ mpi }}  # [mpi != "nompi"]
   run:
     - python
     - numpy
     - readline
     - ncurses
+    - {{ mpi }}  # [mpi != "nompi"]
 
 test:
   requires:


### PR DESCRIPTION
nompi is still the default

cf https://github.com/LFPy/LFPy/issues/47


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->