### PR TITLE
add load_file test

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,3 +50,6 @@ rm -rf $PREFIX/lib/python/neuron
 rm -rf $PREFIX/share/neuron/lib/python
 
 python -c 'import neuron.hoc'
+python -c "import neuron; assert neuron.h.load_file('stdlib.hoc')"
+python -c "import neuron; assert neuron.h.load_file(neuron.h.neuronhome() + '/lib/hoc/stdlib.hoc')"
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,6 +12,10 @@ if [[ "$(uname)" == "Darwin" ]]; then
 else
   export CC=$(basename $CC)
   export CXX=$(basename $CXX)
+  # clear C++ compiler flags, which have been identified
+  # as the culprit
+  export CPPFLAGS="-I$PREFIX/include"
+  export CXXFLAGS="-fPIC -I$PREFIX/include"
 fi
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ build:
 
   # there seem to be references to the build env in the output
   # maybe this is the culprit for failed builds
-  merge_build_host: true
+  merge_build_host: true  # [linux]
 
   # add build string so packages can depend on
   # mpi or nompi variants explicitly:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "7.6.7" %}
 {% set xy = version.rsplit('.', 1)[0] %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% if not mpi %}
 # conda-smithy misbehaves if mpi is unset
@@ -26,6 +26,10 @@ source:
 build:
   number: {{ build }}
   skip: true  # [win]
+
+  # there seem to be references to the build env in the output
+  # maybe this is the culprit for failed builds
+  merge_build_host: true
 
   # add build string so packages can depend on
   # mpi or nompi variants explicitly:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -6,6 +6,6 @@ nrnivmodl
 conda env export -p $CONDA_PREFIX
 
 python -c "import neuron; neuron.test()"
-python -c "import neuron; neuron.h.load_file('stdlib.hoc')"
-python -c "import neuron; neuron.h.load_file(neuron.h.neuronhome() + '/lib/hoc/stdlib.hoc')"
+python -c "import neuron; assert neuron.h.load_file('stdlib.hoc')"
+python -c "import neuron; assert neuron.h.load_file(neuron.h.neuronhome() + '/lib/hoc/stdlib.hoc')"
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -3,10 +3,9 @@ set -ex
 nrnivmodl
 ./x86_64/special --version
 
-python -c "import neuron; neuron.test()"
-python -c "import neuron; neuron.h.load_file('stdlib.hoc')"
-
 conda env export -p $CONDA_PREFIX
 
-python -c "import neuron; neuron.h.load_file(neuron.h.neuronhome() + '/stdlib.hoc')"
+python -c "import neuron; neuron.test()"
+python -c "import neuron; neuron.h.load_file('stdlib.hoc')"
+python -c "import neuron; neuron.h.load_file(neuron.h.neuronhome() + '/lib/hoc/stdlib.hoc')"
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -3,3 +3,5 @@ nrnivmodl
 
 python -c "import neuron; neuron.test()"
 python -c "import neuron; neuron.h.load_file('stdlib.hoc')"
+
+conda env export

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,7 +1,12 @@
+set -ex
+
 nrnivmodl
 ./x86_64/special --version
 
 python -c "import neuron; neuron.test()"
 python -c "import neuron; neuron.h.load_file('stdlib.hoc')"
 
-conda env export
+conda env export -p $CONDA_PREFIX
+
+python -c "import neuron; neuron.h.load_file(neuron.h.neuronhome() + '/stdlib.hoc')"
+

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -2,3 +2,4 @@ nrnivmodl
 ./x86_64/special --version
 
 python -c "import neuron; neuron.test()"
+python -c "import neuron; neuron.h.load_file('stdlib.hoc')"


### PR DESCRIPTION
this is segfaulting in actual installs. There appears to be something in the test env not in real envs.

Even `import neuron` isn't working for mpi builds on linux, despite being tested.

Mostly shooting in the dark to find what's wrong.