### PR TITLE
Adds `CPPFLAGS=""` to configure arguments for MPI builds

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,7 +24,7 @@ autoconf
 
 EXTRA_CONFIG=""
 if [[ ! -z "$mpi" && "$mpi" != "nompi" ]]; then
-  EXTRA_CONFIG="--with-mpi CPPFLAGS='' $EXTRA_CONFIG"
+  EXTRA_CONFIG="--with-mpi --with-paranrn CPPFLAGS=\"\" $EXTRA_CONFIG"
 fi
 
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,7 +24,7 @@ autoconf
 
 EXTRA_CONFIG=""
 if [[ ! -z "$mpi" && "$mpi" != "nompi" ]]; then
-  EXTRA_CONFIG="--with-mpi $EXTRA_CONFIG"
+  EXTRA_CONFIG="--with-mpi CXXFLAGS='' $EXTRA_CONFIG"
 fi
 
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,7 +24,7 @@ autoconf
 
 EXTRA_CONFIG=""
 if [[ ! -z "$mpi" && "$mpi" != "nompi" ]]; then
-  EXTRA_CONFIG="--with-mpi CXXFLAGS='' $EXTRA_CONFIG"
+  EXTRA_CONFIG="--with-mpi CPPFLAGS='' $EXTRA_CONFIG"
 fi
 
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,7 +24,7 @@ autoconf
 
 EXTRA_CONFIG=""
 if [[ ! -z "$mpi" && "$mpi" != "nompi" ]]; then
-  EXTRA_CONFIG="--with-mpi --with-paranrn CPPFLAGS=\"\" $EXTRA_CONFIG"
+  EXTRA_CONFIG="--with-mpi --with-paranrn $EXTRA_CONFIG"
 fi
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ build:
 
   # there seem to be references to the build env in the output
   # maybe this is the culprit for failed builds
-  merge_build_host: true
+  merge_build_host: true  # [linux]
 
   # add build string so packages can depend on
   # mpi or nompi variants explicitly:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "7.6.7" %}
 {% set xy = version.rsplit('.', 1)[0] %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% if not mpi %}
 # conda-smithy misbehaves if mpi is unset
@@ -26,6 +26,10 @@ source:
 build:
   number: {{ build }}
   skip: true  # [win]
+
+  # there seem to be references to the build env in the output
+  # maybe this is the culprit for failed builds
+  merge_build_host: true
 
   # add build string so packages can depend on
   # mpi or nompi variants explicitly:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -3,10 +3,9 @@ set -ex
 nrnivmodl
 ./x86_64/special --version
 
-python -c "import neuron; neuron.test()"
-python -c "import neuron; neuron.h.load_file('stdlib.hoc')"
-
 conda env export -p $CONDA_PREFIX
 
-python -c "import neuron; neuron.h.load_file(neuron.h.neuronhome() + '/stdlib.hoc')"
+python -c "import neuron; neuron.test()"
+python -c "import neuron; neuron.h.load_file('stdlib.hoc')"
+python -c "import neuron; neuron.h.load_file(neuron.h.neuronhome() + '/lib/hoc/stdlib.hoc')"
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -3,3 +3,5 @@ nrnivmodl
 
 python -c "import neuron; neuron.test()"
 python -c "import neuron; neuron.h.load_file('stdlib.hoc')"
+
+conda env export

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,7 +1,12 @@
+set -ex
+
 nrnivmodl
 ./x86_64/special --version
 
 python -c "import neuron; neuron.test()"
 python -c "import neuron; neuron.h.load_file('stdlib.hoc')"
 
-conda env export
+conda env export -p $CONDA_PREFIX
+
+python -c "import neuron; neuron.h.load_file(neuron.h.neuronhome() + '/stdlib.hoc')"
+

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -2,3 +2,4 @@ nrnivmodl
 ./x86_64/special --version
 
 python -c "import neuron; neuron.test()"
+python -c "import neuron; neuron.h.load_file('stdlib.hoc')"


### PR DESCRIPTION
Please ignore, just testing build with `CXXFLAGS=""` added to the list of arguments to `configure`  for MPI builds. Otherwise identical to PR #9 

