### PR TITLE
BUG: Use the correct pinning expression

### DIFF
--- a/.ci_support/osx_64_mpimpichnumpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.19python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpimpichnumpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.19python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpimpichnumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpimpichnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompinumpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.19python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompinumpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.19python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompinumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.19python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.19python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/README.md
+++ b/README.md
@@ -219,16 +219,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `neuron` can be installed with:
+Once the `conda-forge` channel has been enabled, `neuron` can be installed with `conda`:
 
 ```
 conda install neuron
 ```
 
-It is possible to list all of the versions of `neuron` available on your platform with:
+or with `mamba`:
+
+```
+mamba install neuron
+```
+
+It is possible to list all of the versions of `neuron` available on your platform with `conda`:
 
 ```
 conda search neuron --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search neuron --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search neuron --channel conda-forge
+
+# List packages depending on `neuron`:
+mamba repoquery whoneeds neuron --channel conda-forge
+
+# List dependencies of `neuron`:
+mamba repoquery depends neuron --channel conda-forge
 ```
 
 
@@ -246,10 +271,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "8.0.2" %}
 {% set xy = version.rsplit('.', 1)[0] %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% if not mpi %}
 # conda-smithy misbehaves if mpi is unset
@@ -40,9 +40,9 @@ build:
 
   run_exports:
     {% if mpi == "nompi" %}
-    - {{ pin_compatible("neuron") }}
+    - {{ pin_subpackage("neuron") }}
     {% else %}
-    - {{ pin_compatible("neuron") }} {{ mpi_prefix }}_*
+    - {{ pin_subpackage("neuron") }} {{ mpi_prefix }}_*
     {% endif %}
 
 requirements:


### PR DESCRIPTION
pin_compatible only works in the requirements/run section. pin_subpackage is the correct template for run_exports.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
