### PR TITLE
fix and test nrn.version

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,8 +34,10 @@ fi
 # and .gitmodules
 rm -rvf .git*
 
+# default CMAKE_FIND_ROOT_PATH breaks find_path
 CMAKE_CONFIG="$CMAKE_CONFIG \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \
+  -DCMAKE_FIND_ROOT_PATH= \
   -DNRN_ENABLE_SHARED=ON \
   -DIV_ENABLE_SHARED=ON \
   -DNRN_ENABLE_PYTHON=ON \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,8 +31,8 @@ fi
 # not sure there's a benefit to that, since x can just be a lightweight dependency
 
 # remove .git directory from sdist, which fails to load package version
-rm -rf .git
-rm -vf .git*
+# and .gitmodules
+rm -rvf .git*
 
 CMAKE_CONFIG="$CMAKE_CONFIG \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,6 +30,9 @@ fi
 # add -DIV_ENABLE_X11_DYNAMIC=ON to allow x dependencies to be optional?
 # not sure there's a benefit to that, since x can just be a lightweight dependency
 
+# remove .git directory from sdist, which fails to load package version
+rm -rf .git
+
 CMAKE_CONFIG="$CMAKE_CONFIG \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \
   -DNRN_ENABLE_SHARED=ON \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,6 +32,7 @@ fi
 
 # remove .git directory from sdist, which fails to load package version
 rm -rf .git
+rm -vf .git*
 
 CMAKE_CONFIG="$CMAKE_CONFIG \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \

--- a/recipe/project-version.patch
+++ b/recipe/project-version.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/MacroHelper.cmake b/cmake/MacroHelper.cmake
+index 5353242..bb4f1be 100644
+--- a/cmake/MacroHelper.cmake
++++ b/cmake/MacroHelper.cmake
+@@ -296,7 +296,7 @@ function(add_cpp_git_information target scope)
+     set(GIT_DATE "Build Time: ${BUILD_TIME}")
+     set(GIT_BRANCH "unknown branch")
+     set(GIT_CHANGESET "unknown commit id")
+-    set(GIT_DESCRIBE "${PROJECT_VERSION}.dev0")
++    set(GIT_DESCRIBE "${PROJECT_VERSION}")
+     set(GIT_DESCRIBE_FULL "${GIT_DESCRIBE}")
+   endif()
+ 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   version: 9.0.1
-  build: 1
+  build: 2
   mpi_prefix: ${{ 'mpi_' + mpi if mpi != 'nompi' else 'nompi_' }}
 
 package:
@@ -15,6 +15,8 @@ source:
   patches:
     # patch cython compiler error
     - d0d1.patch
+    # patch project version to remove .dev0 from releases
+    - project-version.patch
 
 build:
   # add build string so packages can depend on

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -12,6 +12,8 @@ nrnivmodl
 
 conda env export -p $CONDA_PREFIX
 
+python -c "import os, neuron; assert neuron.version == os.environ['PKG_VERSION'], neuron.version"
+
 python -c "import neuron; neuron.test()"
 python -c "import neuron; assert neuron.h.load_file(neuron.h.neuronhome() + '/lib/hoc/stdlib.hoc')"
 python -c "import neuron; assert neuron.h.load_file('stdlib.hoc')"


### PR DESCRIPTION
releases have partial .git info which leads to an empty nrn.version

removing it leads to a guess with PROJECT_VERSION.dev0, when PROJECT_VERSION is correct.